### PR TITLE
Add query for boot_id.

### DIFF
--- a/athinfo.defs
+++ b/athinfo.defs
@@ -6,6 +6,7 @@
 
 # Query		Command
 
+boot_id		cat /proc/sys/kernel/random/boot_id
 checkServer	/permabit/build/tools/lastrun/checkServer.pl
 checkserver	/permabit/build/tools/lastrun/checkServer.pl
 cpuspeed	grep MHz /proc/cpuinfo

--- a/athinfod.spec
+++ b/athinfod.spec
@@ -4,7 +4,7 @@
 %define name athinfod
 %define version 10.3
 %define unmangled_version 10.3
-%define release 3
+%define release 4
 
 Name:      %{name}
 Version:   %{version}
@@ -68,6 +68,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_presetdir}/01-athinfod.preset
 
 %changelog
+* Wed Jun 28 2023 Joe Shimkus <jshimkus@redhat.com> - 10.3-4
+- Updated athinfo.defs to add boot_id query.
+
 * Mon Aug 22 2022 Joe Shimkus <jshimkus@redhat.com> - 10.3-3
 - Updated athinfo.defs to add scam data queries.
 


### PR DESCRIPTION
Using uptime in testing to determine if a system has rebooted within constraints of a test is unreliable.  Systems that have rebooted occasionally report an uptime longer than that of the test determined elapsed time. boot_id changes on every boot and can be used to determine if reboot has occurred.

Ansible was modified to use this approach: https://github.com/ansible/ansible/pull/47017